### PR TITLE
Issue 36: SPIFFS to BLE

### DIFF
--- a/include/BLE.h
+++ b/include/BLE.h
@@ -21,7 +21,7 @@
 
 #define DEVICE_UUID         0x0180
 #define READ_UUID           0xFEF4
-#define BLE_PAYLOAD_SIZE    247
+#define BLE_PAYLOAD_SIZE    100 // 247
 
 /*************************************Defines***************************************/
 

--- a/include/BLE.h
+++ b/include/BLE.h
@@ -21,6 +21,7 @@
 
 #define DEVICE_UUID         0x0180
 #define READ_UUID           0xFEF4
+#define BLE_PAYLOAD_SIZE    247
 
 /*************************************Defines***************************************/
 

--- a/include/BLE.h
+++ b/include/BLE.h
@@ -21,7 +21,8 @@
 
 #define DEVICE_UUID         0x0180
 #define READ_UUID           0xFEF4
-#define BLE_PAYLOAD_SIZE    100 // 247
+#define BLE_PAYLOAD_SIZE    247 
+#define BLE_MTU             256
 
 /*************************************Defines***************************************/
 

--- a/include/SPIFFS.h
+++ b/include/SPIFFS.h
@@ -22,9 +22,15 @@
 /********************************Public Functions***********************************/
 
 void SPIFFS_init(void); 
-void SPIFFS_Print(const char *path); 
-void SPIFFS_Write(const char *path, const char *data); 
+// void SPIFFS_Print(FILE* f);
+// bool SPIFFS_Dump(FILE* f, char *buffer);
+// void SPIFFS_Write(FILE* f, const char *data);
+void SPIFFS_Print(const char *path);
+size_t SPIFFS_Dump(const char *path, char *buffer, size_t read_size);
+void SPIFFS_Write(const char *path, const char *data);
 void SPIFFS_Clear(const char *path);
+FILE* SPIFFS_Open_File(const char *path);
+bool SPIFFS_Close_File(FILE* f);
 
 /********************************Public Functions***********************************/
 

--- a/include/SPIFFS.h
+++ b/include/SPIFFS.h
@@ -22,15 +22,10 @@
 /********************************Public Functions***********************************/
 
 void SPIFFS_init(void); 
-// void SPIFFS_Print(FILE* f);
-// bool SPIFFS_Dump(FILE* f, char *buffer);
-// void SPIFFS_Write(FILE* f, const char *data);
 void SPIFFS_Print(const char *path);
 size_t SPIFFS_Dump(const char *path, char *buffer, size_t read_size);
 void SPIFFS_Write(const char *path, const char *data);
 void SPIFFS_Clear(const char *path);
-FILE* SPIFFS_Open_File(const char *path);
-bool SPIFFS_Close_File(FILE* f);
 
 /********************************Public Functions***********************************/
 

--- a/include/threads.h
+++ b/include/threads.h
@@ -19,6 +19,7 @@
 
 #define MAX_PROCESSING_PACKETS      3
 #define MAX_SPIFFS_PACKETS          2*MAX_PROCESSING_PACKETS
+#define MAX_PLAY_SESSIONS           5
 
 /*************************************Defines***************************************/
 
@@ -45,6 +46,7 @@ typedef struct vector3D_t {
 } vector3D_t;
 
 typedef struct data_processing_packet_t {
+    // FILE* f;
     char* SPIFFS_file_path;
     bool active;
     uint32_t num_samples;
@@ -53,6 +55,7 @@ typedef struct data_processing_packet_t {
 } data_processing_packet_t;
 
 typedef struct SPIFFS_packet_t {
+    // FILE* f;
     char* SPIFFS_file_path;
     bool active;
     uint16_t test_1;
@@ -60,6 +63,11 @@ typedef struct SPIFFS_packet_t {
     uint16_t test_3;
 } SPIFFS_packet_t;
 
+typedef struct SPIFFS_files_t {
+    uint8_t num_files; 
+    char* file_path[MAX_PLAY_SESSIONS];
+} SPIFFS_files_t;
+extern SPIFFS_files_t SPIFFS_files;
 /****************************Data Structure Definitions*****************************/
 
 /********************************Public Functions***********************************/

--- a/src/BLE.c
+++ b/src/BLE.c
@@ -65,10 +65,9 @@ int BLE_Client_Read(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_
     // printf("%d\n", SPIFFS_files.num_files); 
     // printf("%s\n", SPIFFS_files.file_path[curr_session]);
     if(curr_session < SPIFFS_files.num_files){
-         // Create buffer to store SPIFFS data
+        // Create buffer to store SPIFFS data
         char *buffer = malloc(BLE_PAYLOAD_SIZE);
         size_t bytesRead = SPIFFS_Dump(SPIFFS_files.file_path[curr_session], buffer, BLE_PAYLOAD_SIZE);
-        // size_t bytesRead = SPIFFS_Dump("/spiffs/session_0.txt", buffer, BLE_PAYLOAD_SIZE);
         printf("Read %zu bytes: %.*s\n", bytesRead, (int)bytesRead, buffer); // Debugging
 
         // If file was not empty (or fully read), send the bytes read
@@ -139,9 +138,17 @@ int BLE_GAP_Event_Handler(struct ble_gap_event *event, void *arg){
     return 0; 
 }
 
+// int mtu_event_handler(struct ble_gap_event *event, void *arg) {
+//     if (event->type == BLE_GAP_EVENT_MTU) {
+//         printf("Negotiated MTU: %d\n", event->mtu.value);
+//     }
+//     return 0;
+// }
+
 void BLE_Sync(){
     ble_hs_id_infer_auto(0, &ble_addr_type);
-    BLE_Advertise();                    
+    BLE_Advertise();    
+    // ble_gap_event_listener_register(mtu_event_handler, NULL); // Register MTU callback                
 }
 
 void BLE_Launch(void *param){

--- a/src/SPIFFS.c
+++ b/src/SPIFFS.c
@@ -113,16 +113,14 @@ size_t SPIFFS_Dump(const char *path, char *buffer, size_t read_size){
     size_t bytesRead; 
     // Read payload size amount of bytes in buffer
     if((bytesRead = fread(buffer, 1, read_size, f)) > 0){
-        printf("Read %zu bytes: %.*s\n", bytesRead, (int)bytesRead, buffer);
+        // printf("Read %zu bytes: %.*s\n", bytesRead, (int)bytesRead, buffer);
         dump_position = ftell(f); 
-        fclose(f);
-        return bytesRead; 
     }
     else {
         dump_position = 0; // Reset dump position for next session file.
-        fclose(f);
-        return 0;
     }
+    fclose(f);
+    return bytesRead; 
 }
 
 // void SPIFFS_Write(FILE* f, const char *data){

--- a/src/SPIFFS.c
+++ b/src/SPIFFS.c
@@ -8,7 +8,6 @@
 
 /********************************Public Variables***********************************/
 
-// const char *SPIFFS_TAG = "SPIFFS";
 // For SPIFFS read
 long dump_position = 0;
 
@@ -66,23 +65,6 @@ void SPIFFS_init() {
     }
 }
 
-FILE* SPIFFS_Open_File(const char *path){
-    FILE* f = fopen(path, "a+");
-    if (f == NULL) {
-        ESP_LOGE(SPIFFS_TAG, "Failed to open file.");
-        return NULL;
-    }
-    return f;
-}
-
-bool SPIFFS_Close_File(FILE* f){
-    if(fclose(f) == -1){
-        return false; 
-    }
-    return true; 
-}
-
-// void SPIFFS_Print(FILE* f){
 void SPIFFS_Print(const char *path){
     // ESP_LOGI(SPIFFS_TAG, "Reading file");
     FILE* f = fopen(path, "r");
@@ -99,7 +81,6 @@ void SPIFFS_Print(const char *path){
     // ESP_LOGI(SPIFFS_TAG, "Read %d bytes from file", bytesRead);
 }
 
-// bool SPIFFS_Dump(FILE* f, char *buffer){
 size_t SPIFFS_Dump(const char *path, char *buffer, size_t read_size){
     // Open file
     FILE* f = fopen(path, "r");
@@ -111,7 +92,7 @@ size_t SPIFFS_Dump(const char *path, char *buffer, size_t read_size){
     fseek(f, dump_position, SEEK_SET);
 
     size_t bytesRead; 
-    // Read payload size amount of bytes in buffer
+    // Read size amount of bytes in buffer
     if((bytesRead = fread(buffer, 1, read_size, f)) > 0){
         // printf("Read %zu bytes: %.*s\n", bytesRead, (int)bytesRead, buffer);
         dump_position = ftell(f); 
@@ -123,10 +104,8 @@ size_t SPIFFS_Dump(const char *path, char *buffer, size_t read_size){
     return bytesRead; 
 }
 
-// void SPIFFS_Write(FILE* f, const char *data){
 void SPIFFS_Write(const char *path, const char *data){
     // Append data to file
-    // ESP_LOGI(SPIFFS_TAG, "Appending to file");
     FILE* f = fopen(path, "a");
     if (f == NULL) {
         ESP_LOGE(SPIFFS_TAG, "Failed to open file for appending");

--- a/src/threads.c
+++ b/src/threads.c
@@ -68,7 +68,7 @@ void Play_Session_task(void *args) {
     if(SPIFFS_files.num_files < MAX_PLAY_SESSIONS-1){
         // Add new session to SPIFFS_files
         SPIFFS_files.file_path[SPIFFS_files.num_files] = file_path;
-        // Add the header to the file
+        // Add the header to the file // TODO: Add meaningful header
         char buffer[64];
         sprintf(buffer, "%s\n", file_name);
         SPIFFS_Write(file_path, buffer);
@@ -151,7 +151,6 @@ void Play_Session_task(void *args) {
                 }
                 else {
                     // populate data processing buffer
-                    // play_session_packets[packet_index].f = SPIFFS_files[num_sessions].f;
                     play_session_packets[packet_index].SPIFFS_file_path = file_path;
                     play_session_packets[packet_index].active = true;
                     play_session_packets[packet_index].num_samples = NUM_SAMPLES_TOTAL;
@@ -233,7 +232,6 @@ void Process_Data_task(void *args) {
             srand((unsigned int)xTaskGetTickCount());
 
             // populate data processing buffer
-            // SPIFFS_packets[packet_index].f = packet->f;
             SPIFFS_packets[packet_index].SPIFFS_file_path = packet->SPIFFS_file_path;
             SPIFFS_packets[packet_index].active = true;
             SPIFFS_packets[packet_index].test_1 = (uint16_t)rand();
@@ -290,12 +288,11 @@ void SPIFFS_Write_task(void *args){
             char buffer[64];
             sprintf(buffer, "%d,%d,%d\n", packet->test_1, packet->test_2, packet->test_3);
 
-            // // Write the data 
-            // SPIFFS_Write(packet->f, buffer);
+            // Write the data 
             SPIFFS_Write(packet->SPIFFS_file_path, buffer);
-            SPIFFS_Write(packet->SPIFFS_file_path, buffer);
-            SPIFFS_Write(packet->SPIFFS_file_path, buffer);
-            // SPIFFS_Print(packet->SPIFFS_file_path); // For testing
+            // Can add for easier testing (to make bytes > 247)
+            // SPIFFS_Write(packet->SPIFFS_file_path, buffer);
+            // SPIFFS_Write(packet->SPIFFS_file_path, buffer);
 
             // Give up the semaphore 
             packet->active = false;
@@ -364,6 +361,7 @@ void Button_Manager_task(void *args){
                 if (Button_input == 3) {
                     impact_detected = true;
                 }
+                // For testing with an additional session file
                 if(Button_input == 2){
                     // Test with 2 sessions 
                     const char *file_name = "session_1.txt"; 

--- a/src/threads.c
+++ b/src/threads.c
@@ -293,6 +293,8 @@ void SPIFFS_Write_task(void *args){
             // // Write the data 
             // SPIFFS_Write(packet->f, buffer);
             SPIFFS_Write(packet->SPIFFS_file_path, buffer);
+            SPIFFS_Write(packet->SPIFFS_file_path, buffer);
+            SPIFFS_Write(packet->SPIFFS_file_path, buffer);
             // SPIFFS_Print(packet->SPIFFS_file_path); // For testing
 
             // Give up the semaphore 
@@ -363,11 +365,19 @@ void Button_Manager_task(void *args){
                     impact_detected = true;
                 }
                 if(Button_input == 2){
-                    // char *buffer = malloc(BLE_PAYLOAD_SIZE);
-                    // // bool status = SPIFFS_Dump(SPIFFS_files[num_sessions].f, buffer);
-                    // bool status = SPIFFS_Dump("/spiffs/session_0.txt", buffer, BLE_PAYLOAD_SIZE);
-                    // printf("dump status: %d\n", status);
-                    SPIFFS_Print("/spiffs/session_0.txt");
+                    // Test with 2 sessions 
+                    const char *file_name = "session_1.txt"; 
+                    char file_path[64]; 
+                    sprintf(file_path, "/spiffs/%s", file_name);
+
+                    // Add new session to SPIFFS_files
+                    SPIFFS_files.file_path[SPIFFS_files.num_files] = file_path;
+                    // Add the header to the file
+                    char buffer[64];
+                    sprintf(buffer, "%s\n", file_name);
+                    SPIFFS_Write(file_path, buffer);
+                    SPIFFS_files.num_files++;
+                    printf("%d\n", SPIFFS_files.num_files);
                 }
             }
         }


### PR DESCRIPTION
- Created SPIFFS_Dump function to read MTU Payload size from the file and make it available to BLE. 
- Made global SPIFFS_files_t type to store the SPIFFS session files and the current number of session files. 
- Use BLE to send over the file contents and messages to alert end of file and all sessions dumped. 
**Testing** 
- Upload code and make a number of impacts so the file is written to. 
- Use the button to press twice and simulate starting a new session (no data besides header will actually be written to this file).
- Use the nRFConnect mobile application to connect to 'BLE-Server'
- Once connected you can use the down arrow to 'Read' and you should see the bytes read from the file as well as the end of file and dumping finished messages as you continue to perform reads. 