### PR TITLE
Delete SPIFFS files after dump

### DIFF
--- a/include/SPIFFS.h
+++ b/include/SPIFFS.h
@@ -26,6 +26,7 @@ void SPIFFS_Print(const char *path);
 size_t SPIFFS_Dump(const char *path, char *buffer, size_t read_size);
 void SPIFFS_Write(const char *path, const char *data);
 void SPIFFS_Clear(const char *path);
+void SPIFFS_Delete(const char *path);
 
 /********************************Public Functions***********************************/
 

--- a/src/BLE.c
+++ b/src/BLE.c
@@ -112,6 +112,7 @@ int BLE_GAP_Event_Handler(struct ble_gap_event *event, void *arg){
         ESP_LOGI(BLE_TAG, "Connected Successfully!"); 
         break; 
 
+    // Advertise again if client disconnects. 
     case BLE_GAP_EVENT_DISCONNECT: 
         ESP_LOGI(BLE_TAG, "Connection terminated. Advertising again.");
         BLE_Advertise(); 
@@ -147,6 +148,9 @@ void BLE_End(){
 
     // Shutdown the NimBLE host
     nimble_port_deinit();
+
+    // Reset the current session tracker
+    curr_session = 0; 
 
     ESP_LOGI(BLE_TAG, "Bluetooth session terminated.");
 }

--- a/src/SPIFFS.c
+++ b/src/SPIFFS.c
@@ -93,12 +93,13 @@ size_t SPIFFS_Dump(const char *path, char *buffer, size_t read_size){
     // Read size amount of bytes in buffer
     if((bytesRead = fread(buffer, 1, read_size, f)) > 0){
         dump_position = ftell(f); 
+        fclose(f);
     }
     // Reset dump position for next session file.
     else {
         dump_position = 0; 
+        SPIFFS_Delete(path);
     }
-    fclose(f);
     ESP_LOGI(SPIFFS_TAG, "Read %d bytes from %s.", bytesRead, path);
     return bytesRead; 
 }
@@ -133,5 +134,12 @@ void SPIFFS_Clear(const char *path){
     ESP_LOGI(SPIFFS_TAG, "File cleared successfully.");
 }
 
+void SPIFFS_Delete(const char *path){
+    if (remove(path) == 0) {
+        ESP_LOGI(SPIFFS_TAG, "File %s deleted successfully", path);
+    } else {
+        ESP_LOGE(SPIFFS_TAG, "Failed to delete file %s", path);
+    }
+}
 /********************************Public Functions***********************************/
 

--- a/src/threads.c
+++ b/src/threads.c
@@ -378,8 +378,17 @@ void FSM_task(void *args){
                             state_handler.skip_button_input = true;
                             break;
                         case DOUBLE_PRESS:
-                            ESP_LOGI(FSM_TAG,"Ending BLE session");
+                            // End the BLE session
                             BLE_End(); 
+                            ESP_LOGI(FSM_TAG,"Ending BLE session");
+
+                            // Reset SPIFFS file tracking
+                            for(int i = 0; i < SPIFFS_files.num_files; i++){
+                                SPIFFS_files.file_path[i] = NULL; 
+                            }
+                            SPIFFS_files.num_files = 0; 
+                            
+                            // Reset state handler variables
                             state_handler.BLE_session_active = false; 
                             state_handler.next_state = START;
                             break;


### PR DESCRIPTION
- Updates the SPIFFS file structure in threads.c when files are dumped 
- Updates the curr_session variable in BLE to 0 when BLE session is ended
- Deletes the files from the file system. 